### PR TITLE
Refactor Exchange instance management to ensure a single instance

### DIFF
--- a/WinFormsApp/Form1.cs
+++ b/WinFormsApp/Form1.cs
@@ -8,12 +8,13 @@ namespace WinFormsApp
     {
         private readonly IExchangeFactory _exchangeFactory;
         private readonly IApiKeyStorage _apiKeyStorage;
-        private ICcxtWrapper _ccxt;
+        private ICcxtWrapper? _ccxt;
 
-        public Form1(IExchangeFactory exchangeFactory, IApiKeyStorage apiKeyStorage)
+        public Form1(IExchangeFactory exchangeFactory, IApiKeyStorage apiKeyStorage, ICcxtWrapper? ccxtWrapper)
         {
             _exchangeFactory = exchangeFactory ?? throw new ArgumentNullException(nameof(exchangeFactory));
             _apiKeyStorage = apiKeyStorage ?? throw new ArgumentNullException(nameof(apiKeyStorage));
+            _ccxt = ccxtWrapper; // Assign the ccxtWrapper which might be null
             InitializeComponent();
             InitializeTabs();
         }

--- a/WinFormsApp/Program.cs
+++ b/WinFormsApp/Program.cs
@@ -44,7 +44,7 @@ namespace WinFormsApp
             // Supprimer l'enregistrement de IExchangeOperationsWrapper car il sera créé dynamiquement
 
             // Modifier l'enregistrement de ICcxtWrapper pour qu'il soit créé à la demande
-            services.AddTransient<ICcxtWrapper>(sp =>
+            services.AddSingleton<ICcxtWrapper>(sp =>
             {
                 var factory = sp.GetRequiredService<IExchangeFactory>();
                 var apiKeyStorage = sp.GetRequiredService<IApiKeyStorage>();
@@ -61,7 +61,7 @@ namespace WinFormsApp
                 if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(secretKey))
                 {
                     // Retourner une instance avec des valeurs par défaut ou lancer une exception
-                    throw new InvalidOperationException("Les clés API n'ont pas été configurées. Veuillez les configurer dans l'onglet Configuration.");
+                    return null;
                 }
 
                 var exchange = factory.Create(defaultExchangeId, apiKey, secretKey, sandbox);

--- a/WinFormsApp/SimulationTabControl.cs
+++ b/WinFormsApp/SimulationTabControl.cs
@@ -5,16 +5,23 @@ namespace WinFormsApp
 {
     public partial class SimulationTabControl : UserControl
     {
-        private ICcxtWrapper _ccxt;
+        private ICcxtWrapper? _ccxt; // Allow null
 
-        public SimulationTabControl(ICcxtWrapper ccxt)
+        public SimulationTabControl(ICcxtWrapper? ccxt) // Allow null
         {
-            _ccxt = ccxt ?? throw new ArgumentNullException(nameof(ccxt));
+            _ccxt = ccxt; // Assign directly, can be null
             InitializeComponent();
         }
 
         private async void button1_Click(object sender, EventArgs e)
         {
+            if (_ccxt == null)
+            {
+                label1.Text = "Veuillez configurer une plateforme.";
+                button1.Enabled = false;
+                return;
+            }
+
             button1.Enabled = false;
             label1.Text = "Chargement...";
 
@@ -42,6 +49,9 @@ namespace WinFormsApp
         public void UpdateCcxtWrapper(ICcxtWrapper newCcxt)
         {
             _ccxt = newCcxt ?? throw new ArgumentNullException(nameof(newCcxt));
+            // Reset UI elements as a valid wrapper is provided
+            label1.Text = "Click to load balance"; // Or simply ""
+            button1.Enabled = true;
         }
     }
 }


### PR DESCRIPTION
Previously, Exchange instances (via CcxtWrapper) could be created multiple times. This commit refactors the application to ensure that ICcxtWrapper is a singleton.

Key changes:
- Registered ICcxtWrapper as a singleton in Program.cs. Its initial creation returns null if default API keys are not set, preventing startup crashes.
- Form1 now manages this singleton instance. It's initialized as potentially null and is properly instantiated or updated when a platform is selected or changed via the ConfigTabControl.
- SimulationTabControl is updated to handle a nullable ICcxtWrapper. It disables UI elements if the wrapper isn't available (e.g., on initial startup before platform configuration) and re-enables them when a valid wrapper is provided.

This ensures that only one Exchange connection is active at a time and is reused across the application, only changing when you explicitly select a different platform.